### PR TITLE
Fix requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,19 +10,26 @@ setup(
     author = 'Egor Abramov',
     author_email = 'coreegor@gmail.com',
     version=version,
-    description="Bash 4.2 completion support for Click 8.0.x",
+    description="Bash 4.2 completion support for Click 8",
     py_modules=['click_bash42_completion'],
     include_package_data=True,
     long_description=long_description,
     long_description_content_type='text/markdown',
     download_url=f'https://github.com/coreegor/click-bash4.2-completion/archive/refs/tags/{version}.tar.gz',
-    python_requires='>=3.7',
+    install_requires=[
+        'click>=8.0.0,<9'
+    ],
+    python_requires='>=3.6',
     project_urls={
         'Source': 'https://github.com/coreegor/click-bash4.2-completion',
     },
     classifiers=[
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ]
 
 )


### PR DESCRIPTION
Allow python 3.6, require click 8

click only dropped support for python 3.6 at its version 8.1.0.

There's probably fairly large overlap between the group of people who are stuck on bash 4.2 and the group of people who are stuck on python 3.6 - in particular, I think that Centos 7 users are in that intersection.

So it's desirable that this package is available to those people, who can use it with click 8.0.x.

Also, the dependency on click 8 was missing

